### PR TITLE
fix: DatasetList.get_ids() AttributeError when delayed=True

### DIFF
--- a/gliderpy/fetchers.py
+++ b/gliderpy/fetchers.py
@@ -249,10 +249,10 @@ class DatasetList:
             dataset_ids = self.e.to_pandas()["datasetID"].to_list()
             dataset_ids.remove("allDatasets")
         if not self.delayed:
-            dataset_ids = [                   
+            dataset_ids = [
                 dataset_id
                 for dataset_id in dataset_ids
                 if not dataset_id.endswith("-delayed")
             ]
-        self.dataset_ids = dataset_ids         
+        self.dataset_ids = dataset_ids
         return self.dataset_ids

--- a/gliderpy/fetchers.py
+++ b/gliderpy/fetchers.py
@@ -234,6 +234,7 @@ class DatasetList:
         )
         self.search_for = search_for
         self.delayed = delayed
+        self.dataset_ids: OptionalList = None
 
     def get_ids(self: "DatasetList") -> list:
         """Return the allDatasets list for the glider server."""
@@ -248,11 +249,10 @@ class DatasetList:
             dataset_ids = self.e.to_pandas()["datasetID"].to_list()
             dataset_ids.remove("allDatasets")
         if not self.delayed:
-            self.dataset_ids = [
+            dataset_ids = [                   
                 dataset_id
                 for dataset_id in dataset_ids
                 if not dataset_id.endswith("-delayed")
             ]
-        else:
-            self.dataset_ids = dataset_ids
+        self.dataset_ids = dataset_ids         
         return self.dataset_ids

--- a/gliderpy/fetchers.py
+++ b/gliderpy/fetchers.py
@@ -253,4 +253,6 @@ class DatasetList:
                 for dataset_id in dataset_ids
                 if not dataset_id.endswith("-delayed")
             ]
+        else:
+            self.dataset_ids = dataset_ids
         return self.dataset_ids


### PR DESCRIPTION
Fixes #173

Two small changes to `DatasetList` in `gliderpy/fetchers.py`:

1. Initialize `self.dataset_ids = None` in `__init__` for consistency with `GliderDataFetcher`
2. Fix `get_ids()` so `self.dataset_ids` is correctly assigned for both `delayed=True` and `delayed=False`

## Problem

`self.dataset_ids` was only assigned inside the `if not self.delayed:` block. When `delayed=True`, this block was skipped but the method still attempted to `return self.dataset_ids`, which was never set, causing:

```
AttributeError: 'DatasetList' object has no attribute 'dataset_ids'
```

## Changes

**`__init__`:** Added explicit initialization:
```python
self.dataset_ids: OptionalList = None
```

**`get_ids()`:** Moved assignment outside the conditional block. 

```python
if not self.delayed:
    dataset_ids = [
        dataset_id
        for dataset_id in dataset_ids
        if not dataset_id.endswith("-delayed")
    ]
self.dataset_ids = dataset_ids
return self.dataset_ids
```

## Testing

All 8 existing tests pass. `DatasetList` currently has no test coverage.